### PR TITLE
log4j2 configuration for production mode

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -38,7 +38,11 @@ communikey:
                 -----END PUBLIC KEY-----
 
 server:
+  address: localhost
   port: 8080
   compression:
     enabled: true
     mime-types: application/json
+
+logging:
+  config: classpath:log4j2.yml

--- a/src/main/resources/log4j2-dev.yml
+++ b/src/main/resources/log4j2-dev.yml
@@ -6,7 +6,7 @@ Configutation:
       name: CONSOLE
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight{%5p} [%t] %c{1}: %m%n"
+        Pattern: "[%highlight{%-5level}] %d{yyyy-MM-dd HH:mm:ss.SSS} <%t> %c{1}: %m%n"
 
   Loggers:
     Root:
@@ -14,7 +14,7 @@ Configutation:
       AppenderRef:
         - ref: CONSOLE
     Logger:
-      - name: de.communicode.communikey.service
+      - name: de.communicode.communikey
         additivity: false
         level: debug
         AppenderRef:

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -1,0 +1,26 @@
+Configutation:
+  status: warn
+
+  Appenders:
+    RollingFile:
+      - name: COMMUNIKEY
+        fileName: "./logs/communikey.log"
+        filePattern: "./logs/$${date:yyyy-MM}/my-app-%d{yyyy-MM-dd}-%i.log.gz"
+        PatternLayout:
+          Pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} <%t> %c{1}: %m%n"
+        policies:
+          TimeBasedTriggeringPolicy:
+            interval: 1
+            modulate: true
+
+  Loggers:
+    Root:
+      level: warn
+      AppenderRef:
+        - ref: COMMUNIKEY
+    Logger:
+      - name: de.communicode.communikey
+        additivity: false
+        level: info
+        AppenderRef:
+          - ref: COMMUNIKEY

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,7 +4,3 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
-
-server:
-  address: localhost
-  port: 8080


### PR DESCRIPTION
<p align="center"><img src="https://svn.apache.org/repos/asf/logging/graphics/log4j/log4j2-logo-w3000.png" width="40%" /></p>

> Closes #15

This PR adds a [log4j2][] configuration for production mode with optimized settings and a file appender. It also adapts the new log pattern for the development mode configuration.

The process on how to increase the logging level [will be added to the documentation][doc-card]. 

[log4j2]: http://logging.apache.org/log4j/2.x
[doc-card]: https://github.com/communicode/communikey-docs/projects/2#card-9517503