### PR TITLE
GitHub issue- and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -11,6 +11,7 @@ Please do your best to provide as much information as possible and use a clear a
 * **Ensure the issue has not already been reported by using the [GitHub Issues search](https://github.com/communicode/communikey-backend/issues)** — if it has **and the issue is still open**, add a comment to the existing issue instead of opening this new one. If you find a closed issue that seems to be similar to this one, include a link to the original issue in the [metadata head](#metadata-head) section of this issue.
 * **Ensure the contribution belongs to the correct [communikey repository](https://github.com/communicode?q=communikey).**
 * **Ensure the issue is reproducible** — try to use the [latest version](https://github.com/communicode/communikey-backend/releases/latest) and [`develop`](https://github.com/communicode/communikey-backend/tree/develop) branch.
+* **Remove not fitting sections of this template based on the type of the issue**
 
 ## Metadata Head
 
@@ -34,7 +35,19 @@ Set the *type* of this issue. It determines which information will be required i
 
 ## Description
 
-Describe the enhancement or bug as in many relevant details as possible. If this is a enhancement suggestion add specific use-cases and explain why this feature or improvement would be useful. If this is a bug provide ensure to fill in the [steps to reproduce](#steps-to-reproduce) it.
+Describe the enhancement or bug as in many relevant details as possible. If this is a bug provide ensure to fill in the [steps to reproduce](#steps-to-reproduce) it.
+
+### Benefits
+
+If this is a enhancement suggestion add specific use-cases and explain why this feature or improvement would be useful and maybe include references to related known problems or bug reports.
+
+### Possible Drawbacks
+
+If this is a enhancement suggestion describe possible negative impacts regarding e.g. functionality or usability.
+
+### Alternative Solutions
+
+If this is a enhancement suggestion please describe clearly and concise if you've considered alternative features or solutions.
 
 ### Steps to Reproduce
 
@@ -74,6 +87,10 @@ Paste the full stack trace, error messages or the logfile here ...
 ```
 
 ... or [attach them as files](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests) to this issue.
+
+## Additional Context
+
+Add any other context, screenshots or screencasts which are relevant for this issue.
 
 ## References
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,84 @@
+<!-- Click on the "Preview" tab to render the instructions in a more readable format -->
+
+> **Please read the [contribution guidelines](https://github.com/communicode/communikey-backend/blob/develop/CONTRIBUTING.md) before filling out this issue template**.
+
+## Prerequisites
+
+This section and the instructions in the sections below are only part of this issue template. Please ensure to **delete this whole section, all pre-filled instructions of the sections below and sections you have not filled out before submitting** to ensure a clear structure and overview.
+
+Please do your best to provide as much information as possible and use a clear and descriptive title for your enhancement suggestion or bug report to help maintainers and the community understand and reproduce the behavior, find related reports and to resolve the ticket faster.
+
+* **Ensure the issue has not already been reported by using the [GitHub Issues search](https://github.com/communicode/communikey-backend/issues)** — if it has **and the issue is still open**, add a comment to the existing issue instead of opening this new one. If you find a closed issue that seems to be similar to this one, include a link to the original issue in the [metadata head](#metadata-head) section of this issue.
+* **Ensure the contribution belongs to the correct [communikey repository](https://github.com/communicode?q=communikey).**
+* **Ensure the issue is reproducible** — try to use the [latest version](https://github.com/communicode/communikey-backend/releases/latest) and [`develop`](https://github.com/communicode/communikey-backend/tree/develop) branch.
+
+## Metadata Head
+
+The metadata head should be added to the top of the issue as [Markdown text quote](https://help.github.com/articles/basic-writing-and-formatting-syntax) containing the [issue type](#issue-type) and if necessary the ID of other related issues.
+
+> Issue type:
+Related issues:
+
+### Issue Type
+
+Set the *type* of this issue. It determines which information will be required in the following sections when it is an [bug report](https://github.com/communicode/communikey-backend/blob/develop/CONTRIBUTING.md#bug-reports) or an [enhancement suggestion](https://github.com/communicode/communikey-backend/blob/develop/CONTRIBUTING.md#enhancement-suggestions).
+
+* *bug*
+* *feature*
+* *improvement*
+* *proposal*
+* *question*
+* *rfc*
+* *subtask*
+* *task*
+
+## Description
+
+Describe the enhancement or bug as in many relevant details as possible. If this is a enhancement suggestion add specific use-cases and explain why this feature or improvement would be useful. If this is a bug provide ensure to fill in the [steps to reproduce](#steps-to-reproduce) it.
+
+### Steps to Reproduce
+
+1. Step One
+2. Step Two
+3. ...
+
+### Expected Behavior
+
+What you expect to happen?
+
+### Actual Behavior
+
+What actually happens?
+
+## Example
+
+Provide a [MCVE - The Minimal, Complete, and Verifiable Example](https://github.com/communicode/communikey-backend/blob/develop/CONTRIBUTING.md#mcve)
+
+**This is a optional section, but it can drastically increase the speed at which this issue can be processed since it takes away the time-consuming reconstruction to reproduce the enhancement or bug.**
+
+The recommended way is to upload it as [Gist](https://gist.github.com) or new repository to GitHub, but of course you can [attach it to this issue](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests), use any free file hosting service or paste the code in [Markdown code blocks](https://help.github.com/articles/basic-writing-and-formatting-syntax) into this issue.
+
+## Environment and Versions
+
+* What is the version of communikey you are running?
+* What is the name and the version of your OS?
+  * Have you tried to reproduce it on different OS environments and if yes is the behavior the same for all?
+* If the problem is related to [Java](https://www.java.com) please provide the Java version you're running.
+  * Are you using any additional CLI arguments for Java or Gradle?
+* What is the version of [Gradle](https://gradle.org) you are running?
+
+## Stack Trace and Error Messages
+
+```
+Paste the full stack trace, error messages or the logfile here ...
+```
+
+... or [attach them as files](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests) to this issue.
+
+## References
+
+Add any other references and links which are relevant for this issue.
+
+## Potential Solution
+
+If this is a bug report this might include the lines of code that you have identified as causing the bug or in case of an enhancement suggestion references to other projects where this enhancement already exists.

--- a/.github/ISSUE_TEMPLATE/bugs.md
+++ b/.github/ISSUE_TEMPLATE/bugs.md
@@ -1,0 +1,80 @@
+---
+name: Bug Report
+about: Report a bug that is caused by the code in this repository
+
+---
+
+<!-- Click on the "Preview" tab to render the instructions in a more readable format -->
+
+> **Please read the [contribution guidelines](https://github.com/communicode/communikey-backend/blob/develop/CONTRIBUTING.md) before filling out this issue template**.
+
+## Prerequisites
+
+This section and the instructions in the sections below are only part of this issue template. Please ensure to **delete this whole section, all pre-filled instructions of the sections below and sections you have not filled out before submitting** to ensure a clear structure and overview.
+
+Please do your best to provide as much information as possible and use a clear and descriptive title for your bug report to help maintainers and the community understand and reproduce the behavior, find related reports and to resolve the ticket faster.
+
+* **Ensure the issue has not already been reported by using the [GitHub Issues search](https://github.com/communicode/communikey-backend/issues)** — if it has **and the issue is still open**, add a comment to the existing issue instead of opening this new one. If you find a closed issue that seems to be similar to this one, include a link to the original issue(s) in the [metadata head](#metadata-head) section of this issue.
+* **Ensure the contribution belongs to the correct [communikey repository](https://github.com/communicode?q=communikey).**
+* **Ensure the issue is reproducible** — try to use the [latest version](https://github.com/communicode/communikey-backend/releases/latest) and [`develop`](https://github.com/communicode/communikey-backend/tree/develop) branch.
+
+## Metadata Head
+
+The metadata head can be added to the top of the issue as [Markdown text quote](https://help.github.com/articles/basic-writing-and-formatting-syntax) containing the the ID of other related issues.
+
+> Related issues:
+
+## Description
+
+Describe the bug as in many relevant details as possible with a clear and concise description. Ensure to fill in the [steps to reproduce](#steps-to-reproduce) it.
+
+### Steps to Reproduce
+
+1. Step One
+2. Step Two
+3. ...
+
+### Expected Behavior
+
+What you expect to happen?
+
+### Actual Behavior
+
+What actually happens?
+
+## Example
+
+Provide a [MCVE - The Minimal, Complete, and Verifiable Example](https://github.com/communicode/communikey-backend/blob/develop/CONTRIBUTING.md#mcve)
+
+**This is a optional section, but it can drastically increase the speed at which this issue can be processed since it takes away the time-consuming reconstruction to reproduce the bug.**
+
+The recommended way is to upload it as [Gist](https://gist.github.com) or new repository to GitHub, but of course you can [attach it to this issue](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests), use any free file hosting service or paste the code in [Markdown code blocks](https://help.github.com/articles/basic-writing-and-formatting-syntax) into this issue.
+
+## Environment and Versions
+
+* What is the version of communikey you are running?
+* What is the name and the version of your OS?
+  * Have you tried to reproduce it on different OS environments and if yes is the behavior the same for all?
+* If the problem is related to [Java](https://www.java.com) please provide the Java version you're running.
+  * Are you using any additional CLI arguments for Java or Gradle?
+* What is the version of [Gradle](https://gradle.org) you are running?
+
+## Stack Trace and Error Messages
+
+```
+Paste the full stack trace, error messages or the logfile here ...
+```
+
+... or [attach them as files](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests) to this issue.
+
+## Additional Context
+
+Add any other context, screenshots or screencasts which are relevant for this issue.
+
+## References
+
+Add any other references and links which are relevant for this issue.
+
+## Potential Solution
+
+Maybe include the lines of code that you have identified as causing the bug or references to other projects where this bug has already been reported.

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,62 @@
+---
+name: Enhancement Suggestions
+about: Submit an enhancement suggestion for new features or minor improvements to existing functionality
+
+---
+
+<!-- Click on the "Preview" tab to render the instructions in a more readable format -->
+
+> **Please read the [contribution guidelines](https://github.com/communicode/communikey-backend/blob/develop/CONTRIBUTING.md) before filling out this issue template**.
+
+## Prerequisites
+
+This section and the instructions in the sections below are only part of this issue template. Please ensure to **delete this whole section, all pre-filled instructions of the sections below and sections you have not filled out before submitting** to ensure a clear structure and overview.
+
+Please do your best to provide as much information as possible and use a clear and descriptive title for your enhancement suggestion to help maintainers and the community understand and reproduce the behavior, find related reports and to resolve the ticket faster.
+
+* **Ensure the issue has not already been reported by using the [GitHub Issues search](https://github.com/communicode/communikey-backend/issues)** — if it has **and the issue is still open**, add a comment to the existing issue instead of opening this new one. If you find a closed issue that seems to be similar to this one, include a link to the original issue in the [metadata head](#metadata-head) section of this issue.
+* **Ensure the contribution belongs to the correct [communikey repository](https://github.com/communicode?q=communikey).**
+* If your feature request 
+* **Ensure the issue is reproducible** — try to use the [latest version](https://github.com/communicode/communikey-backend/releases/latest) and [`develop`](https://github.com/communicode/communikey-backend/tree/develop) branch.
+
+## Metadata Head
+
+The metadata head can be added to the top of the issue as [Markdown text quote](https://help.github.com/articles/basic-writing-and-formatting-syntax) containing the ID of other related issues.
+
+> Related issues:
+
+## Description
+
+Describe the enhancement in many relevant details as possible.
+
+### Benefits
+
+Add specific use-cases and explain why this feature or improvement would be useful and maybe include references to related known problems or bug reports.
+
+### Possible Drawbacks
+
+Describe possible negative impacts regarding e.g. functionality or usability.
+
+### Alternative Solutions
+
+If you've considered alternative features or solutions please describe it clearly and concise.
+
+## Example
+
+Provide a [MCVE - The Minimal, Complete, and Verifiable Example](https://github.com/communicode/communikey-backend/blob/develop/CONTRIBUTING.md#mcve)
+
+**This is a optional section, but it can drastically increase the speed at which this issue can be processed since it takes away the time-consuming reconstruction to reproduce the enhancement.**
+
+The recommended way is to upload it as [Gist](https://gist.github.com) or new repository to GitHub, but of course you can [attach it to this issue](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests), use any free file hosting service or paste the code in [Markdown code blocks](https://help.github.com/articles/basic-writing-and-formatting-syntax) into this issue.
+
+## Additional Context
+
+Add any other context, screenshots or screencasts which are relevant for this issue.
+
+## References
+
+Add any other references and links which are relevant for this issue.
+
+## Potential Solution
+
+Maybe include references to other projects where this enhancement already exists.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,9 +14,9 @@ Please do your best to provide as much information as possible and use a clear a
 
 ## Metadata Head
 
-The metadata head should be added to the top of the pull request as [Markdown text quote](https://help.github.com/articles/basic-writing-and-formatting-syntax) containing the [GitHub issue keywords][gh-help-issue-keywords] to link to the related enhancements suggestions (`Closes`) or bug reports (`Fixes`). You can add additional details like dependencies to other pull requests and the order it needs to be merged.
+The metadata head should be added to the top of the pull request as [Markdown text quote](https://help.github.com/articles/basic-writing-and-formatting-syntax) containing the [GitHub issue keyword(s)](https://help.github.com/articles/closing-issues-using-keywords) to link to the related enhancements suggestions (`Closes`) or bug reports (`Fixes`). You can add additional details like dependencies to other pull requests and the order it needs to be merged.
 
-> Closes ISSUE_ID
+> Closes ISSUE_ID  
 Must be merged **after**/**before** ISSUE_ID
 
 ## Description

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!-- Click on the "Preview" tab to render the instructions in a more readable format -->
+
+> **Please read the [contribution guidelines](https://github.com/communicode/communikey-backend/blob/develop/CONTRIBUTING.md) before filling out this pull request template**.
+
+## Prerequisites
+
+This section and the instructions in the sections below are only part of this pull request template. Please ensure to **delete this whole section, all pre-filled instructions of the sections below and sections you have not filled out before submitting** to ensure a clear structure and overview.
+
+Please do your best to provide as much information as possible and use a clear and descriptive title for your enhancement suggestion or bug fix to help maintainers and the community understand and reproduce the behavior, find related pull requests and to merge it faster.
+
+* **Ensure the pull request has not already been reported by using the [GitHub Pull Request search](https://github.com/communicode/communikey-backend/pulls)** — if it has **and the pull request is still open**, add a comment to the existing pull request instead of opening this new one. If you find a closed pull request that seems to be similar to this one, include a link to it in the [metadata head](#metadata-head) section of this pull request.
+* **Ensure the contribution belongs to the correct [communikey repository](https://github.com/communicode?q=communikey).**
+* **Ensure to adhere to the [pull request contribution guidelines](https://github.com/communicode/communikey-backend/blob/develop/CONTRIBUTING.md#pull-requests)**, especially the one for tests and documentations.
+
+## Metadata Head
+
+The metadata head should be added to the top of the pull request as [Markdown text quote](https://help.github.com/articles/basic-writing-and-formatting-syntax) containing the [GitHub issue keywords][gh-help-issue-keywords] to link to the related enhancements suggestions (`Closes`) or bug reports (`Fixes`). You can add additional details like dependencies to other pull requests and the order it needs to be merged.
+
+> Closes ISSUE_ID
+Must be merged **after**/**before** ISSUE_ID
+
+## Description
+
+Describe the changes as in many relevant details as possible. If this is a enhancement suggestion add specific use-cases and explain why this feature or improvement would be useful. If this is a bug fix ensure to provide a *before/after* comparison by describing the current behavior and the new behavior.
+
+## References
+
+Add any other references and links which are relevant for this issue.


### PR DESCRIPTION
> Closes #10 
Blocked by #18 (must be merged **after**)

This PR also adapts to the new [issue template improvements blog post][bp].

[bp]: https://blog.github.com/2018-05-02-issue-template-improvements/
[b]:  https://github.com/communicode/communikey-backend/issues/templates/edit

![](https://blog.github.com/assets/img/2018-04-30-issue-templates/new-issue-page-with-multiple-templates.png)